### PR TITLE
Windows Media Creation Tool pointed to Norwegian language version

### DIFF
--- a/docs/recommendations/whitelist.md
+++ b/docs/recommendations/whitelist.md
@@ -16,7 +16,7 @@ This serves as a master list of recommended and permitted software that we permi
 | Type | Name | Notes |
 | -- | -- | -- |
 | Disk Manipulation | [gparted](https://rtech.support/docs/disks/gparted) | Gparted is a Linux/GNU front-end to the parted tool. It is the recommended method for manipulating disks when using a Linux live session. [How To Set Up](https://rtech.support/books/troubleshooting-with-a-linux-live-session/page/manipulating-partitions-and-disks-with-gparted) |
-| Bootable USB Solutions | [Windows Media Creation Tool](https://www.microsoft.com/nb-no/software-download/windows10) | Microsoft's official tool used to do a clean install of Windows 10 and 11. |
+| Bootable USB Solutions | [Windows Media Creation Tool](https://www.microsoft.com/en-us/software-download/windows10) | Microsoft's official tool used to do a clean install of Windows 10 and 11. |
 || [Rufus](https://rufus.ie/en_US/) | A portable Windows program used to flash ISOs onto USB flash drives.|
 || [Etcher](https://www.balena.io/etcher/) | A cross-platform program used to flash non-Windows ISOs onto USB flash drives. |
 || [Ventoy](https://rtech.support/books/how-to-and-guides/page/how-to-install-and-use-ventoy) | A multiboot solution for USBs.|


### PR DESCRIPTION
The link for the Windows Media Creation Tool is for the Norwegian language site, which doesn't make much sense and is inconsistent with the rest of this wiki. I changed it to the correct link.