### PR TITLE
Add: llcd footer to BSOD wiki

### DIFF
--- a/docs/factoids/bsod.md
+++ b/docs/factoids/bsod.md
@@ -58,3 +58,7 @@ First, double check the dump configuration settings following the guide [here](h
 If your file is stuck on `Processing...` when uploading it to Discord, you are attemping to upload a dump file directly from the Minidump folder. Depending on your account's permissions, Windows prevents this but does not provide any sort of notification. Please follow the steps above to copy and upload the entire Minidump folder rather than the individual dump files.
 
 If you're curious, we use [WinDbg](https://docs.microsoft.com/en-us/windows-hardware/drivers/debugger/debugger-download-tools) to analyze the dump.
+
+## Unable to access windows desktop
+
+If you are unable to access the windows desktop even after troubleshooting steps like booting into [safemode](https://support.microsoft.com/en-us/windows/start-your-pc-in-safe-mode-in-windows-92c27cff-db89-8644-1ce4-b3e5e56fe234) you can try following our tutorial on [Live Linux USB's](https://rtech.support/docs/live-sessions/linux-live-session.html) to obtain and send us the dump files created by windows. However, please note that in most situations. If you are unable to enter the desktop environment you will be suggested to [re-install windows](https://rtech.support/windows).


### PR DESCRIPTION
I thought it would be beneficial to add a footer section about llcd's in the event the user can't access their desktop.

There was an event like this in the techsupport discord when this idea was discussed between me and Comrade Korl
![image](https://github.com/r-Techsupport/rTS_Wiki/assets/66909997/725b85f9-228e-4a4f-b76e-f7d24658e781)
