### PR TITLE
Issue #190 improvements

### DIFF
--- a/docs/guides/making-a-system-dossier.md
+++ b/docs/guides/making-a-system-dossier.md
@@ -14,18 +14,25 @@ redirect_from: /books/how-to-and-guides/page/making-a-system-dossier
 
 {% include toc.md %}
 
-## What is a system dossier?
-A system dossier is a great way to provide needed information about your computer (hardware, software, and OS). While you could list it all by hand, some problems can require a lot of information, and it would be time-consuming to obtain it all manually. The more info you can provide about your computer the easier it is for someone to diagnose your issue, and the more accurate their advice will be.
-
 ## General System Information
 None of the tools here do everything, but oftentimes all of them don't need to be run.
-### Specs (Get-Specs)
-Specs is a small tool made by us that gets a bunch of info about your hardware, software, and OS, and allows convenient ways to save and share it. You can download it [here](https://github.com/r-Techsupport/Get-Specs/releases/latest/download/Get-Specs.zip).
+### Specify
+Specify is a tool that gathers information about your OS, software, and hardware, and allows convenient ways to save and share it. You can download Specify [here](https://spec-ify.com/download).
 
-Once downloaded, extract the zip file and run `Specs.exe`. Follow the prompts, and it will eventually give you an option to upload the snapshot to our pastebin or to view the file on your computer. Uploading the file will last for 24 hours. Either way, the file will be saved in `TechSupport_Specs.html`.
+To use this tool, run `Specify.exe` and follow the prompts. Once done, it will automatically open a link and copy it to your clipboard.
+ 
+Links are automatically deleted after 24 hours. You can choose to redact your username and/or OneDrive commercial name from the report if you feel it's sensitive information.
+> ℹ️ If you receive a "Windows protected your PC" pop up, click `More info` then `Run anyway`.
+>
+> 📶 For machines without internet access, select the "Don't Upload" option. Upload `specify_specs.json` to the [official website](https://spec-ify.com/) to generate a report.
 
-Alternatively, you can use [Speccy](https://www.ccleaner.com/speccy/download/standard) to get similar information.
+### Get-Specs
+Alternatively, you can use [Get-Specs](https://github.com/r-Techsupport/Get-Specs/releases/latest/download/Get-Specs.zip) to get similar information.
 
+To use this tool, extract `Get-Specs.zip` and run `Specs.cmd` inside the newly extracted folder. Click "Start" and once done, click "Upload" to open a link and copy it to your clipboard, or click "View" to open a `.html` file in your browser. 
+
+Links are automatically deleted after 24 hours, a permanent `TechSupport_Specs.html` file will be generated in the folder regardless.
+> ℹ️: Do *not* move, modify, or delete any files inside of the extracted folder. If you receive a "Windows protected your PC" pop up, click `More info` then `Run anyway`.
 ### msinfo32
 msinfo32 is built into Windows. It will provide some of the same information Speccy does. This is more focused on hardware and OS than installed software.
 

--- a/docs/guides/making-a-system-dossier.md
+++ b/docs/guides/making-a-system-dossier.md
@@ -32,7 +32,7 @@ Alternatively, you can use [Get-Specs](https://github.com/r-Techsupport/Get-Spec
 To use this tool, extract `Get-Specs.zip` and run `Specs.cmd` inside the newly extracted folder. Click "Start" and once done, click "Upload" to open a link and copy it to your clipboard, or click "View" to open a `.html` file in your browser. 
 
 Links are automatically deleted after 24 hours. A permanent `TechSupport_Specs.html` file will be generated in the folder regardless.
-> ℹ️: Do *not* move, modify, or delete any files inside of the extracted folder. If you receive a "Windows protected your PC" pop up, click `More info` then `Run anyway`.
+> ℹ️: **Do not move, modify, or delete any files inside of the extracted folder.** If you receive a "Windows protected your PC" pop up, click `More info` then `Run anyway`.
 ### msinfo32
 msinfo32 is built into Windows. It will provide some of the same information Speccy does. This is more focused on hardware and OS than installed software.
 

--- a/docs/guides/making-a-system-dossier.md
+++ b/docs/guides/making-a-system-dossier.md
@@ -17,7 +17,7 @@ redirect_from: /books/how-to-and-guides/page/making-a-system-dossier
 ## General System Information
 None of the tools here do everything, but oftentimes all of them don't need to be run.
 ### Specify
-Specify is a tool that gathers information about your OS, software, and hardware, and allows convenient ways to save and share it. You can download Specify [here](https://spec-ify.com/download).
+[Specify](https://github.com/Spec-ify) is a tool that gathers information about your OS, software, and hardware, and allows convenient ways to save and share it. You can download Specify [here](https://spec-ify.com/download).
 
 To use this tool, run `Specify.exe` and follow the prompts. Once done, it will automatically open a link and copy it to your clipboard.
  
@@ -27,11 +27,11 @@ Links are automatically deleted after 24 hours. You can choose to redact your us
 > 📶 For machines without internet access, select the "Don't Upload" option. Upload `specify_specs.json` to the [official website](https://spec-ify.com/) to generate a report.
 
 ### Get-Specs
-Alternatively, you can use [Get-Specs](https://github.com/r-Techsupport/Get-Specs/releases/latest/download/Get-Specs.zip) to get similar information.
+Alternatively, you can use [Get-Specs](https://github.com/r-Techsupport/Get-Specs) to get similar information. You can download Get-Specs [here](https://github.com/r-Techsupport/Get-Specs/releases/latest/download/Get-Specs.zip)
 
 To use this tool, extract `Get-Specs.zip` and run `Specs.cmd` inside the newly extracted folder. Click "Start" and once done, click "Upload" to open a link and copy it to your clipboard, or click "View" to open a `.html` file in your browser. 
 
-Links are automatically deleted after 24 hours, a permanent `TechSupport_Specs.html` file will be generated in the folder regardless.
+Links are automatically deleted after 24 hours. A permanent `TechSupport_Specs.html` file will be generated in the folder regardless.
 > ℹ️: Do *not* move, modify, or delete any files inside of the extracted folder. If you receive a "Windows protected your PC" pop up, click `More info` then `Run anyway`.
 ### msinfo32
 msinfo32 is built into Windows. It will provide some of the same information Speccy does. This is more focused on hardware and OS than installed software.

--- a/docs/guides/making-a-system-dossier.md
+++ b/docs/guides/making-a-system-dossier.md
@@ -14,6 +14,9 @@ redirect_from: /books/how-to-and-guides/page/making-a-system-dossier
 
 {% include toc.md %}
 
+## What is a system dossier?
+A system dossier is a great way to provide needed information about your computer (hardware, software, and OS). While you could list it all by hand, some problems can require a lot of information, and it would be time-consuming to obtain it all manually. The more info you can provide about your computer the easier it is for someone to diagnose your issue, and the more accurate their advice will be.
+
 ## General System Information
 None of the tools here do everything, but oftentimes all of them don't need to be run.
 ### Specify

--- a/docs/recommendations/temps-voltages.md
+++ b/docs/recommendations/temps-voltages.md
@@ -1,3 +1,4 @@
+---
 layout: default
 title: Reading Machine Temperatures & Voltages
 nav_exclude: false

--- a/docs/recommendations/temps-voltages.md
+++ b/docs/recommendations/temps-voltages.md
@@ -20,12 +20,12 @@ Watching your temperatures is an important part of managing any machine, especia
 When reporting your temperatures to people, please use Celsius. It doesn't matter what country you are in, everyone uses Celsius for computers.
 
 ## Specify
-This is an all around system reporting tool. We use this actively in our [Discord live chat](/discord) to gather system information, including temperatures as reported by various sensors.
+This is an all around system reporting tool. We use this actively in our [Discord live chat](/discord) to gather system information, including temperatures reported by various sensors.
 
 You can download Specify [here](https://spec-ify.com/download). Temperatures (including their corresponding sensors) are listed in the "Temps" section of the Specify report.
 
 ### Get-Specs
-Alternatively, you can use Get-Specs to gather similar information 
+Alternatively, you can use Get-Specs to gather similar information.
 
 You can download Get-Specs [here](https://github.com/r-Techsupport/Get-Specs/releases/latest/download/Get-Specs.zip). Temperatures are listed in the "Hardware Basics" section of the report.
 

--- a/docs/recommendations/temps-voltages.md
+++ b/docs/recommendations/temps-voltages.md
@@ -1,7 +1,3 @@
-## Specify
-This is an all around system reporting tool. We use this actively in [the Discord](/discord) to gather system information, including temperatures. You can download Specify [here](
-
-<!--Speccy can have some issues reading Ryzen, if you temps are incredibly high please check with a Ryzen specific tool.-->---
 layout: default
 title: Reading Machine Temperatures & Voltages
 nav_exclude: false

--- a/docs/recommendations/temps-voltages.md
+++ b/docs/recommendations/temps-voltages.md
@@ -20,13 +20,16 @@ Watching your temperatures is an important part of managing any machine, especia
 When reporting your temperatures to people, please use Celsius. It doesn't matter what country you are in, everyone uses Celsius for computers.
 
 ## Specify
-This is an all around system reporting tool. We use this actively in our [Discord live chat](/discord) to gather system information, including temperatures.
+This is an all around system reporting tool. We use this actively in our [Discord live chat](/discord) to gather system information, including temperatures and their corresponding sensors.
 
-You can download Specify [here](https://spec-ify.com/download). Temperatures, including the hardware component(s) and sensors reporting them are listed in the "Temps" section of the Specify report.
+You can download Specify [here](https://spec-ify.com/download). Temperatures (including their corresponding sensors) are listed in the "Temps" section of the Specify report.
 
-> ℹ️ For more information on how to use Specify and Get-Specs, please see our page on making a system dossier.
+### Get-Specs
+Alternatively, you can use Get-Specs to gather similar (albeit more basic/limited) information 
 
+You can download Get-Specs [here](https://github.com/r-Techsupport/Get-Specs/releases/latest/download/Get-Specs.zip). Temperatures are listed in the "Hardware Basics" section of the report.
 
+> ℹ️ **For more information on how to use Specify and Get-Specs, please see our guide on [making a system dossier](docs/guides/making-a-system-dossier.md).**
 
 ## Ryzen Master
 The go-to for ensuring you get proper temperature readings for your Ryzen CPU. If other tools show the same temperature you can assume they are accurate.
@@ -34,6 +37,6 @@ The go-to for ensuring you get proper temperature readings for your Ryzen CPU. I
 [Download](https://download.amd.com/Desktop/AMD-Ryzen-Master.exe)
 
 ## HWiNFO
-Like Specs, this has a ton of info, but it is isolated to hardware. We utilize this for extended logging of voltages, temps, etc. during stress tests.
+Like Specify, this has a ton of info, but it is isolated to hardware. We utilize this for extended logging of voltages, temps, etc. during stress tests.
 
 [Download](https://www.hwinfo.com/download/)

--- a/docs/recommendations/temps-voltages.md
+++ b/docs/recommendations/temps-voltages.md
@@ -1,4 +1,7 @@
----
+## Specify
+This is an all around system reporting tool. We use this actively in [the Discord](/discord) to gather system information, including temperatures. You can download Specify [here](
+
+<!--Speccy can have some issues reading Ryzen, if you temps are incredibly high please check with a Ryzen specific tool.-->---
 layout: default
 title: Reading Machine Temperatures & Voltages
 nav_exclude: false
@@ -16,14 +19,14 @@ Watching your temperatures is an important part of managing any machine, especia
 
 When reporting your temperatures to people, please use Celsius. It doesn't matter what country you are in, everyone uses Celsius for computers.
 
-## Specs
-This is an all around system reporting tool. We use this actively in [the Discord](/discord) to get a ton of information about your machine. 
+## Specify
+This is an all around system reporting tool. We use this actively in our [Discord live chat](/discord) to gather system information, including temperatures.
 
-<!--Speccy can have some issues reading Ryzen, if you temps are incredibly high please check with a Ryzen specific tool.-->
+You can download Specify [here](https://spec-ify.com/download). Temperatures, including the hardware component(s) and sensors reporting them are listed in the "Temps" section of the Specify report.
 
-[Download](https://github.com/r-Techsupport/Get-Specs/releases/latest/download/Get-Specs.zip)
+> ℹ️ For more information on how to use Specify and Get-Specs, please see our page on making a system dossier.
 
-Alternatively, you can use [Speccy](https://www.ccleaner.com/speccy/download/standard) to get similar information.
+
 
 ## Ryzen Master
 The go-to for ensuring you get proper temperature readings for your Ryzen CPU. If other tools show the same temperature you can assume they are accurate.

--- a/docs/recommendations/temps-voltages.md
+++ b/docs/recommendations/temps-voltages.md
@@ -20,12 +20,12 @@ Watching your temperatures is an important part of managing any machine, especia
 When reporting your temperatures to people, please use Celsius. It doesn't matter what country you are in, everyone uses Celsius for computers.
 
 ## Specify
-This is an all around system reporting tool. We use this actively in our [Discord live chat](/discord) to gather system information, including temperatures and their corresponding sensors.
+This is an all around system reporting tool. We use this actively in our [Discord live chat](/discord) to gather system information, including temperatures as reported by various sensors.
 
 You can download Specify [here](https://spec-ify.com/download). Temperatures (including their corresponding sensors) are listed in the "Temps" section of the Specify report.
 
 ### Get-Specs
-Alternatively, you can use Get-Specs to gather similar (albeit more basic/limited) information 
+Alternatively, you can use Get-Specs to gather similar information 
 
 You can download Get-Specs [here](https://github.com/r-Techsupport/Get-Specs/releases/latest/download/Get-Specs.zip). Temperatures are listed in the "Hardware Basics" section of the report.
 


### PR DESCRIPTION
Updated [Making a System Dossier](docs/guides/making-a-system-dossier.html) to suggest Specify and Get-Specs, rather than Get-Specs and Speccy, and added detailed instructions on how to install and use both tools. 

Also updated [Reading Machine Temperatures & Voltages](docs/recommendations/temps-voltages.html) with basic instructions on where to find temperature information in a Specify/Get-Specs report, with a link to Making a System Dossier.