### PR TITLE
Remove note about requiring CSM.

### DIFF
--- a/docs/guides/memtest/memtest86.md
+++ b/docs/guides/memtest/memtest86.md
@@ -24,7 +24,6 @@ Follow the [Linux media guide](/docs/installations/install-linux#step-2-creating
 
 ## Run Memtest86+
 
-**This media needs to be booted in Legacy/CSM mode. They will not work when loaded in UEFI mode**
 If you used the official Memtest86+ media, it will boot straight into the test.
 
 ## 3. Results


### PR DESCRIPTION
Remove note about requiring CSM. Memtest will boot in UEFI now.