### PR TITLE
add gha to delete a branch once a PR is merged

### DIFF
--- a/.github/workflows/del-branch-on-merge
+++ b/.github/workflows/del-branch-on-merge
@@ -1,0 +1,24 @@
+name: Delete branch after merge
+
+on:
+  pull_request:
+    types: [closed]
+
+jobs:
+  delete_branch:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Delete branch
+        run: |
+          branch=${{ github.event.pull_request.head.ref }}
+          author=${{ github.event.pull_request.user.login }}
+          if [ "$branch" != "main" ] && [ "$branch" != "master" ] && [ "$author" != "dependabot[bot]" ]; then
+            git push origin --delete $branch
+          fi
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This will delete a branch that was merged in a PR

Unless the PR was made by Dependabot to prevent failures 