### PR TITLE
Update install-11.mdx

### DIFF
--- a/src/content/docs/installations/install-11.mdx
+++ b/src/content/docs/installations/install-11.mdx
@@ -78,7 +78,7 @@ import LinuxInstallMedia from '../../../_includes/embeds/create-linux-install-me
  
 * Secure boot is enabled
  
-* TPM is enabled
+* TPM is enabled (Intel® Platform Trust Technology (Intel® PTT)/ fTPM)
  
 * The drive controller mode is set to AHCI/NVMe, and with RAID/VMD/IRST disabled
 


### PR DESCRIPTION
I have noticed that the Windows 11 install guide has been heavily improved by making it vastly more concise than before, however one of the changes made is that it no longer specifies what TPM is often called in the BIOS, therefore I propose a minor adjustment so that it has in brackets (fTPM and Intel Platform Trust Technology) just so it is clearer for end users what they need to enable.